### PR TITLE
[HOTFIX] #56 페이지별 테마설정 이슈

### DIFF
--- a/app/src/main/java/com/haman/daangnphoto/MainActivity.kt
+++ b/app/src/main/java/com/haman/daangnphoto/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.haman.core.designsystem.theme.DaangnPhotoTheme
 import com.haman.daangnphoto.ui.DaangnPhotoApp
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -15,9 +14,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            DaangnPhotoTheme {
-                DaangnPhotoApp(splashScreen)
-            }
+            DaangnPhotoApp(splashScreen)
         }
     }
 }

--- a/app/src/main/java/com/haman/daangnphoto/ui/DaangnPhotoApp.kt
+++ b/app/src/main/java/com/haman/daangnphoto/ui/DaangnPhotoApp.kt
@@ -12,6 +12,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.haman.core.common.state.UiEvent
 import com.haman.core.designsystem.component.Toast
+import com.haman.core.designsystem.theme.DaangnPhotoTheme
 import com.haman.daangnphoto.MainViewModel
 import com.haman.daangnphoto.navigation.DaangnNavHost
 import kotlinx.coroutines.delay
@@ -39,13 +40,15 @@ fun DaangnPhotoApp(
         else timeOutSplashScreen.value.not()
     }
 
-    Scaffold {
-        Box(modifier = Modifier.fillMaxSize()) {
-            DaangnNavHost(
-                navController = navController,
-                mainViewModel = viewModel
-            )
-            Event(event = uiEvent.value)
+    DaangnPhotoTheme {
+        Scaffold {
+            Box(modifier = Modifier.fillMaxSize()) {
+                DaangnNavHost(
+                    navController = navController,
+                    mainViewModel = viewModel
+                )
+                Event(event = uiEvent.value)
+            }
         }
     }
 }

--- a/core/designsystem/src/main/java/com/haman/core/designsystem/theme/DanngnBlackTheme.kt
+++ b/core/designsystem/src/main/java/com/haman/core/designsystem/theme/DanngnBlackTheme.kt
@@ -1,11 +1,10 @@
 package com.haman.core.designsystem.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.runtime.Composable
 
-private val ColorPalette = darkColors(
+private val DarkColorPalette = darkColors(
     primary = Orange800,
     onPrimary = White,
     background = Gray900,
@@ -15,9 +14,11 @@ private val ColorPalette = darkColors(
 )
 
 @Composable
-fun DaangnBlackTheme(content: @Composable () -> Unit) {
+fun DaangnBlackTheme(
+    content: @Composable () -> Unit
+) {
     MaterialTheme(
-        colors = ColorPalette,
+        colors = DarkColorPalette,
         typography = Typography,
         shapes = Shapes,
         content = content

--- a/feature/detail/src/main/java/com/haman/feature/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/haman/feature/detail/DetailScreen.kt
@@ -3,6 +3,7 @@ package com.haman.feature.detail
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Icon
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -40,35 +41,39 @@ fun DetailScreen(
         }
     }
 
-    Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Icon(
+    Surface {
+        Box(
             modifier = Modifier
-                .align(Alignment.TopEnd)
-                .size(24.dp)
-                .clickable { onBackPressed() },
-            painter = painterResource(id = DaangnIcons.close),
-            contentDescription = "close button"
-        )
-        Column(
-            modifier = Modifier
-                .align(Alignment.Center)
-                .padding(vertical = 24.dp),
-            verticalArrangement = Arrangement.Center
+                .fillMaxSize()
         ) {
-            if (imageState.value?.author != null) {
-                SubTitle(
-                    modifier = Modifier.padding(8.dp),
-                    text = "by ${imageState.value?.author}"
-                )
-            }
-            imageState.value?.let {
-                AsyncImage(
-                    image = it,
-                    loadImage = viewModel::getImageByUrl,
-                    scaleType = ContentScale.FillWidth
-                )
+            Icon(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(12.dp)
+                    .size(24.dp)
+                    .clickable { onBackPressed() },
+                painter = painterResource(id = DaangnIcons.close),
+                contentDescription = "close button"
+            )
+            Column(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(vertical = 24.dp),
+                verticalArrangement = Arrangement.Center
+            ) {
+                if (imageState.value?.author != null) {
+                    SubTitle(
+                        modifier = Modifier.padding(8.dp),
+                        text = "by ${imageState.value?.author}"
+                    )
+                }
+                imageState.value?.let {
+                    AsyncImage(
+                        image = it,
+                        loadImage = viewModel::getImageByUrl,
+                        scaleType = ContentScale.FillWidth
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
### 📌 내용
상세 화면에서는 DaangnTheme가 아닌 DaangnBlackTheme가 적용되어야 하는데, 적용이 안되있던 문제 수정

### 🛠 To Do
- [x] 메인화면에는 DaangnTheme 설정
- [x] 상세화면에는 DaangnBlackTheme 설정

### 🍿 수정방법
DetailScreen의 가장 상단에는 Box Component가 위치합니다.
Box Component인 경우 DaangnPhotoApp에서 지정한 DaangnPhotoTheme가 적용되게 됩니다.😭

이 때문에 DaangnBlackTheme가 아닌 DaangnTheme가 적용되었으며, 
이를 수정하기 위해 Box Component를 content color를 지정할 수 있는 Surface로 한번 더 감싸게 되었습니다.

<img width="540" alt="스크린샷 2023-03-07 오전 11 54 39" src="https://user-images.githubusercontent.com/22411296/223308303-bc8467fb-160e-4666-9e89-a16df685092b.png">

### 🪴 결과 화면
👇🏻 Light Theme에서도  Dark Theme로 보이는 상세 화면

https://user-images.githubusercontent.com/22411296/223308534-44587204-1d7a-4177-9ecc-83b88c692c39.mp4

### 🏠 관련 Issue
Closed #56 

