### PR TITLE
[HOTFIX|REFACTOR] #63 Network Module Scope 수정하기

### DIFF
--- a/core/network/src/main/java/com/haman/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/haman/core/network/di/NetworkModule.kt
@@ -19,8 +19,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
-    @Singleton
     @Provides
+    @Singleton
     fun provideImageApiService(
         retrofit: Retrofit
     ): ImageApiService = retrofit.create(ImageApiService::class.java)
@@ -30,6 +30,7 @@ object NetworkModule {
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
     @Provides
+    @Singleton
     fun provideRetrofit(
         okHttpClient: OkHttpClient,
         converter: Converter.Factory
@@ -46,6 +47,7 @@ object RetrofitModule {
 @InstallIn(SingletonComponent::class)
 object ConvertFactoryModule {
     @Provides
+    @Singleton
     fun provideJsonConverter(): Converter.Factory {
         return Json {
             coerceInputValues = true // null 값으로 들어오면 default value로 처리
@@ -60,6 +62,7 @@ object HttpClientModule {
     private const val TIMEOUT = 3L
 
     @Provides
+    @Singleton
     fun provideHttpClient(): OkHttpClient {
         val interceptor = HttpLoggingInterceptor()
         interceptor.level = if (BuildConfig.DEBUG) {


### PR DESCRIPTION
### 📌 내용
ImageApiService와 Retrofit 생성에 필요한 모든 모듈들의 Scope를 @Singleton으로 수정하기

### 🛠 변경 사항
결국은 Api Service 인스턴스 자체가 아닌 Api Service의 메서드를 호출할 때마다
- 서버 연결
- Request / Response

작업이 수행되므로 Api Service를 생성하는 쪽도 Retrofit을 생성하는 쪽도 Singleton을 붙여주었습니다.

### 🪴 해당 내용 관련 정리글
https://rien-atelier.tistory.com/165

### 🏠 관련 Issue
Closed #63 
